### PR TITLE
90% Wrap JSON.parse in try..catch. Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node Client for Babel
 ## Getting Started
 Install the module:
 
-```npm install node_client@git://github.com/talis/babel-node-client.git#0.1.0 --save```
+```npm install node_client@git://github.com/talis/babel-node-client.git#0.3.2 --save```
 
 Create a babel client as follows:
 
@@ -65,6 +65,8 @@ babelClient.createAnnotations(token, data, function(error, results){
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+
+0.3.2 - Safely parses JSON responses. Fixes #5.
 
 0.3.1 - Fixes
   * Now correctly validates hasTarget property when creating annotations. hasTarget can be a single object or an array of objects.

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ BabelClient.prototype.getTargetFeed = function(target, token, hydrate, callback)
         throw new Error('Missing Persona token');
     }
 
+    var self = this;
+
     hydrate = hydrate || false;
 
     var requestOptions = {
@@ -68,15 +70,7 @@ BabelClient.prototype.getTargetFeed = function(target, token, hydrate, callback)
         if(err){
             callback(err);
         } else{
-            var jsonBody = JSON.parse(body);
-
-            if(jsonBody.error){
-                var babelError = new Error(jsonBody.error_description);
-                babelError.http_code = response.statusCode || 404;
-                callback(babelError);
-            } else{
-                callback(null, jsonBody);
-            }
+            self._parseJSON(response, body, callback);
         }
     });
 };
@@ -99,6 +93,8 @@ BabelClient.prototype.getFeeds = function (feeds, token, callback) {
         throw new Error('Missing Persona token');
     }
 
+    var self = this;
+
     feeds = feeds.join(",");
 
     var requestOptions = {
@@ -115,15 +111,7 @@ BabelClient.prototype.getFeeds = function (feeds, token, callback) {
         if (err) {
             callback(err);
         } else {
-            var jsonBody = JSON.parse(body);
-
-            if (jsonBody.error) {
-                var babelError = new Error(jsonBody.error_description);
-                babelError.http_code = response.statusCode || 404;
-                callback(babelError);
-            } else {
-                callback(null, jsonBody);
-            }
+            self._parseJSON(response, body, callback);
         }
     });
 };
@@ -148,6 +136,8 @@ BabelClient.prototype.getAnnotations = function(token, querystringMap, callback)
         throw new Error('Missing Persona token');
     }
 
+    var self = this;
+
     querystringMap = querystringMap || {};
 
     var requestOptions = {
@@ -164,15 +154,7 @@ BabelClient.prototype.getAnnotations = function(token, querystringMap, callback)
         if(err){
             callback(err);
         } else{
-            var jsonBody = JSON.parse(body);
-
-            if(jsonBody.error){
-                var babelError = new Error(jsonBody.error_description);
-                babelError.http_code = response.statusCode || 404;
-                callback(babelError);
-            } else{
-                callback(null, jsonBody);
-            }
+            self._parseJSON(response, body, callback);
         }
     });
 
@@ -283,6 +265,29 @@ BabelClient.prototype.createAnnotation = function(token, data, options, callback
     });
 };
 
+/**
+ * Parse JSON safely
+ * @param {object} response
+ * @param {object} body
+ * @callback callback
+ * @private
+ */
+BabelClient.prototype._parseJSON = function(response, body, callback){
+    try{
+        var jsonBody = JSON.parse(body);
+
+        if(jsonBody.error){
+            var babelError = new Error(jsonBody.error_description);
+            babelError.http_code = response.statusCode || 404;
+            callback(babelError);
+        } else{
+            callback(null, jsonBody);
+        }
+    } catch(e){
+        var babelError = new Error("Error parsing JSON: "+body);
+        callback(babelError);
+    }
+};
 
 /**
  * Log wrapping functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-node-client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Babel",

--- a/test/unit/babel_client_test.js
+++ b/test/unit/babel_client_test.js
@@ -206,6 +206,28 @@ describe("Babel Node Client Test Suite", function(){
             });
             done();
         });
+        it("should not blow up if invalid JSON returned", function(done){
+            var babel = rewire("../../index.js");
+
+            var babelClient = babel.createClient({
+                babel_host:"http://babel",
+                babel_port:3000
+            });
+
+            var requestStub = function(options, callback){
+                callback(null, {}, null);
+            };
+
+            babel.__set__("request", requestStub);
+
+            babelClient.getTargetFeed('TARGET', 'secret', {}, function(err, result){
+
+              (err === null).should.be.false;
+              err.message.should.equal('Error parsing JSON: null');
+              (typeof result).should.equal('undefined');
+            });
+            done();
+        });
     });
 
     describe("- Test Querying Multiple Feeds", function(){
@@ -367,6 +389,28 @@ describe("Babel Node Client Test Suite", function(){
             });
             done();
         });
+        it("should not blow up if invalid JSON returned", function(done){
+            var babel = rewire("../../index.js");
+
+            var babelClient = babel.createClient({
+                babel_host:"http://babel",
+                babel_port:3000
+            });
+
+            var requestStub = function(options, callback){
+                callback(null, {}, null);
+            };
+
+            babel.__set__("request", requestStub);
+
+            babelClient.getFeeds(['FEED1', ['FEED2']], 'secret', function(err, result){
+
+                (err === null).should.be.false;
+                err.message.should.equal('Error parsing JSON: null');
+                (typeof result).should.equal('undefined');
+            });
+            done();
+        });
     });
 
     describe("- Get Annotations Feed tests", function(){
@@ -483,6 +527,28 @@ describe("Babel Node Client Test Suite", function(){
                 result.count.should.equal(2);
                 result.limit.should.equal(25);
                 result.annotations.should.have.lengthOf(2);
+            });
+            done();
+        });
+        it("should not blow up if invalid JSON returned", function(done){
+            var babel = rewire("../../index.js");
+
+            var babelClient = babel.createClient({
+                babel_host:"http://babel",
+                babel_port:3000
+            });
+
+            var requestStub = function(options, callback){
+               callback(null, {}, null);
+            };
+
+            babel.__set__("request", requestStub);
+
+            babelClient.getAnnotations('secret', {}, function(err, result){
+
+                (err === null).should.be.false;
+                err.message.should.equal('Error parsing JSON: null');
+                (typeof result).should.equal('undefined');
             });
             done();
         });


### PR DESCRIPTION
This wraps all calls to JSON.parse in a try..catch so it doesn't bomb out the node process when it encounters non-json.