### PR TITLE
Add host header for haproxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "0.11"
   - "0.10"
 
-before_install: npm install -g grunt grunt-cli
+before_install: npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "0.11"
   - "0.10"
 
-before_install: npm install -g grunt-cli
+before_install: npm install -g grunt grunt-cli

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ BabelClient.prototype.headTargetFeed = function(target, token, params, callback)
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 
@@ -126,7 +126,7 @@ BabelClient.prototype.getTargetFeed = function(target, token, hydrate, params, c
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 
@@ -168,7 +168,7 @@ BabelClient.prototype.getFeeds = function (feeds, token, callback) {
         headers: {
             'Accept': 'application/json',
             'Authorization': 'Bearer ' + token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 
@@ -250,7 +250,7 @@ BabelClient.prototype.getAnnotations = function(token, querystringMap, callback)
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 
@@ -344,7 +344,7 @@ BabelClient.prototype.createAnnotation = function(token, data, options, callback
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ BabelClient.prototype.getAnnotation = function(token, id, callback) {
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': 'babel'
+            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ var BabelClient = function (config) {
     if(!this.config.babel_host.match('^http')){
         throw new Error('Invalid Babel config: babel_host');
     }
+
+    this.config.babel_hostname = this.config.babel_host.split('://', 2)[1];
 };
 
 /**
@@ -68,7 +70,7 @@ BabelClient.prototype.headTargetFeed = function(target, token, params, callback)
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 
@@ -126,7 +128,7 @@ BabelClient.prototype.getTargetFeed = function(target, token, hydrate, params, c
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 
@@ -168,7 +170,7 @@ BabelClient.prototype.getFeeds = function (feeds, token, callback) {
         headers: {
             'Accept': 'application/json',
             'Authorization': 'Bearer ' + token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 
@@ -206,7 +208,7 @@ BabelClient.prototype.getAnnotation = function(token, id, callback) {
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 
@@ -250,7 +252,7 @@ BabelClient.prototype.getAnnotations = function(token, querystringMap, callback)
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 
@@ -344,7 +346,7 @@ BabelClient.prototype.createAnnotation = function(token, data, options, callback
         headers: {
             'Accept': 'application/json',
             'Authorization':'Bearer '+token,
-            'Host': this.config.babel_host.replace(/^(https?:|)\/\//, '')
+            'Host': this.config.babel_hostname
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ BabelClient.prototype.headTargetFeed = function(target, token, params, callback)
           '/feeds/targets/'+md5(target)+'/activity/annotations' + (!_.isEmpty(queryString) ? '?'+queryString : ''),
         headers: {
             'Accept': 'application/json',
-            'Authorization':'Bearer '+token
+            'Authorization':'Bearer '+token,
+            'Host': 'babel'
         }
     };
 
@@ -124,7 +125,8 @@ BabelClient.prototype.getTargetFeed = function(target, token, hydrate, params, c
           '/feeds/targets/'+md5(target)+'/activity/annotations'+((hydrate === true) ? '/hydrate' : '') + (!_.isEmpty(queryString) ? '?'+queryString : ''),
         headers: {
             'Accept': 'application/json',
-            'Authorization':'Bearer '+token
+            'Authorization':'Bearer '+token,
+            'Host': 'babel'
         }
     };
 
@@ -165,7 +167,8 @@ BabelClient.prototype.getFeeds = function (feeds, token, callback) {
         url: this.config.babel_host + ':' + this.config.babel_port + '/feeds/annotations/hydrate?feed_ids=' + encodeURIComponent(feeds),
         headers: {
             'Accept': 'application/json',
-            'Authorization': 'Bearer ' + token
+            'Authorization': 'Bearer ' + token,
+            'Host': 'babel'
         }
     };
 
@@ -202,7 +205,8 @@ BabelClient.prototype.getAnnotation = function(token, id, callback) {
         url: this.config.babel_host+':'+this.config.babel_port+'/annotations/'+id,
         headers: {
             'Accept': 'application/json',
-            'Authorization':'Bearer '+token
+            'Authorization':'Bearer '+token,
+            'Host': 'babel'
         }
     };
 
@@ -245,7 +249,8 @@ BabelClient.prototype.getAnnotations = function(token, querystringMap, callback)
         url: this.config.babel_host+':'+this.config.babel_port+'/annotations?'+querystring.stringify(querystringMap),
         headers: {
             'Accept': 'application/json',
-            'Authorization':'Bearer '+token
+            'Authorization':'Bearer '+token,
+            'Host': 'babel'
         }
     };
 
@@ -338,7 +343,8 @@ BabelClient.prototype.createAnnotation = function(token, data, options, callback
         url: this.config.babel_host+':'+this.config.babel_port+'/annotations',
         headers: {
             'Accept': 'application/json',
-            'Authorization':'Bearer '+token
+            'Authorization':'Bearer '+token,
+            'Host': 'babel'
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-node-client",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "main": "./index.js",
   "description": "Node Client for Babel",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-watch": "~0.5.0",
     "grunt-jsbeautifier": "~0.2.6",


### PR DESCRIPTION
Docker primitives cluster works by redirecting traffic via haproxy, so we can go through port 80 for all the primitives.
However, the Request library we use in Critic doesn't play nicely when we specify port 80 unless we also specify the Host when making the request.

I've tried updating the Request library to the latest one and that doesn't fix the problem.

So the only alternative to this would be 
- remove the *requirement* for a port when using this library - like we do in https://github.com/talis/echo-node-client/ where you just provide an echo endpoint - or only add a port if it's specified and otherwise don't add one - since it seems to work fine when no port is specified 
- use a different request library (assuming we don't want to do this although it does seem to have a bug :( )

This probably would be improved by having 3 params: HOST, PORT and SCHEME like persona-node-client