### PR TITLE
90% PLAT-1871 Check HTTP Status Codes for non 200 responses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 .idea
 node_modules
 npm-debug.log

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
         if(err){
             callback(err);
         } else{
-            if(body.message && body.errors){
+            if(!this.responseSuccessful(response) || (body.message && body.errors)){
                 var babelError = new Error(body.message);
                 babelError.http_code = response.statusCode || 404;
                 callback(babelError);
@@ -372,7 +372,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
                 callback(null, body);
             }
         }
-    });
+    }.bind(this));
 };
 
 /**
@@ -461,7 +461,7 @@ BabelClient.prototype.updateAnnotation = function updateAnnotation(token, data, 
         if (err) {
             callback(err);
         } else {
-            if (body.message && body.errors) {
+            if(!this.responseSuccessful(response) || (body.message && body.errors)){
                 var babelError = new Error(body.message);
                 babelError.http_code = response.statusCode || 404;
                 callback(babelError);
@@ -469,7 +469,7 @@ BabelClient.prototype.updateAnnotation = function updateAnnotation(token, data, 
                 callback(null, body);
             }
         }
-    });
+    }.bind(this));
 };
 
 /**
@@ -605,6 +605,15 @@ BabelClient.prototype.debug = function debug(message) {
 };
 BabelClient.prototype.error = function error(message) {
     this._log(ERROR, message);
+};
+
+BabelClient.prototype.responseSuccessful = function responseSuccessful(response) {
+    if (response && response.statusCode) {
+        if (response.statusCode >= 200 && response.statusCode <= 299) {
+            return true;
+        }
+    }
+    return false;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ BabelClient.prototype.createAnnotation = function createAnnotation(token, data, 
         if(err){
             callback(err);
         } else{
-            if(!this.responseSuccessful(response) || (body.message && body.errors)){
+            if(!this._responseSuccessful(response) || (body.message && body.errors)){
                 var babelError = new Error(body.message);
                 babelError.http_code = response.statusCode || 404;
                 callback(babelError);
@@ -461,7 +461,7 @@ BabelClient.prototype.updateAnnotation = function updateAnnotation(token, data, 
         if (err) {
             callback(err);
         } else {
-            if(!this.responseSuccessful(response) || (body.message && body.errors)){
+            if(!this._responseSuccessful(response) || (body.message && body.errors)){
                 var babelError = new Error(body.message);
                 babelError.http_code = response.statusCode || 404;
                 callback(babelError);
@@ -607,7 +607,7 @@ BabelClient.prototype.error = function error(message) {
     this._log(ERROR, message);
 };
 
-BabelClient.prototype.responseSuccessful = function responseSuccessful(response) {
+BabelClient.prototype._responseSuccessful = function responseSuccessful(response) {
     if (response && response.statusCode) {
         if (response.statusCode >= 200 && response.statusCode <= 299) {
             return true;

--- a/test/unit/babel_client_test.js
+++ b/test/unit/babel_client_test.js
@@ -976,6 +976,31 @@ describe("Babel Node Client Test Suite", function(){
             });
         });
 
+        it("- should return an error if call to request returns a none 200 response", function(done){
+            var babel = rewire("../../index.js");
+
+            var babelClient = babel.createClient({
+                babel_host:"http://babel",
+                babel_port:3000
+            });
+            var requestStub = {
+                post:function(options, callback){
+                   var response = {statusCode: 400};
+                    callback(null, response, {body:'', message:'Bad Request'});
+                }
+            };
+
+            babel.__set__("request", requestStub);
+
+            babelClient.createAnnotation('secret', {hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, {}, function(err, result){
+
+                (err === null).should.be.false;
+                err.message.should.equal('Bad Request');
+                (typeof result).should.equal('undefined');
+                done();
+            });
+        });
+
         it("- should return no errors if everything is successful", function(done){
 
             var babel = rewire("../../index.js");
@@ -987,7 +1012,7 @@ describe("Babel Node Client Test Suite", function(){
 
             var requestMock = {};
             requestMock.post = function(options, callback){
-                callback(null, {}, {
+                callback(null, {statusCode: 201}, {
                     __v: 0,
                     annotatedBy: 'Gordon Freeman',
                     _id: '12345678901234567890',
@@ -1033,7 +1058,7 @@ describe("Babel Node Client Test Suite", function(){
 
             var requestMock = {};
             requestMock.post = function(options, callback){
-                callback(null, {}, {
+                callback(null, {statusCode: 201}, {
                     __v: 0,
                     annotatedBy: 'Gordon Freeman',
                     _id: '12345678901234567890',
@@ -1307,6 +1332,30 @@ describe("Babel Node Client Test Suite", function(){
             });
         });
 
+        it("- should return an error if call to request returns a none 200 response", function(done){
+            var babel = rewire("../../index.js");
+
+            var babelClient = babel.createClient({
+                babel_host:"http://babel",
+                babel_port:3000
+            });
+            var requestStub = {
+                put:function(options, callback){
+                    var response = {statusCode: 400};
+                    callback(null, response, {body:'', message:'Bad Request'});
+                }
+            };
+
+            babel.__set__("request", requestStub);
+
+            babelClient.updateAnnotation('secret', {_id: 'testid', hasBody:{format:'text/plain', type:'Text'}, hasTarget:{uri:'http://example.com'}, annotatedBy:'Gordon Freeman'}, function(err, result){
+                (err === null).should.be.false;
+                err.message.should.equal('Bad Request');
+                (typeof result).should.equal('undefined');
+                done();
+            });
+        });
+
         it("- should return no errors if everything is successful", function(done){
             var babel = rewire("../../index.js");
 
@@ -1317,7 +1366,7 @@ describe("Babel Node Client Test Suite", function(){
 
             var requestMock = {};
             requestMock.put = function(options, callback){
-                callback(null, {}, {
+                callback(null, {statusCode: 200}, {
                     __v: 0,
                     annotatedBy: 'Gordon Freeman',
                     _id: '12345678901234567890',


### PR DESCRIPTION
#### Problem

babel-server is returning a 400 response for requests, but this is not being translated into an error in the client. 

This client is checking the body of the response for the json property errors. The response reported in PLAT-1871 contained the error in an error property rather than an errors property.

#### Fix

We could change the node client to check for error. Would we need it to check for errors too?

The correct solution here is to listen to HTTP response codes rather than looking for error or errors in the response body.

This PR makes the node client error if the response code is not the 2xx range.

I did consider completely removing the existing code checking for the existence of errors in the body. However, without checking all responses are correctly using error codes, I'm reluctant to do that. If we have been checking for errors using this mechanism, it's possible we are returning errors without using the correct status code.

For now, I'm adding in a new check for the status code, but leaving in the existing code to ensure there is no unexpected behavior from this change. At some point, we should audit all responses from babel-server and if it's ok, remove the checking for the existence of errors in the body completely. But not now.
